### PR TITLE
apply BUILD_FOR_ARCH for spa plugin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ layout:
     bind: $SNAP/etc/pulse
 
 environment:
-  SPA_PLUGIN_DIR: $SNAP/usr/lib/x86_64-linux-gnu/spa-0.2
+  SPA_PLUGIN_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/spa-0.2
   LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pipewire-0.3
 
 apps:


### PR DESCRIPTION
### Description
Hey Sergio, thanks for building this snap, this is very useful as a sound server running on Ubuntu Core. I have tried this snap on a ARM64 platform running Ubuntu core, but I got some erros while I issue wpctl command.

while we run into the confined environment of this snap on a ARM64 system running Ubuntu Core, the wireplumber utilities and pipewire utilities is not working, such as wpctl, pw-cli.

I have verified this issue with a local build snap (with this fixed) and it works well. 

### Solutions
update the SPA_PLUGIN_DIR with CRAFT_ARCH_TRIPLET_BUILD_FOR variable in snapcraft yaml