### PR TITLE
Add pipewire slot

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,8 +49,7 @@ apps:
     passthrough:
       daemon-scope: user
     slots:
-# we have to wait until this is added to the store
-#      - pipewire
+      - pipewire
       - audio-playback
       - audio-record
       - pulseaudio


### PR DESCRIPTION
Now that the pipewire slot is available in the store and in the store tools, it's time to add it to the snap.