### PR TITLE
Add alsa-ucm-conf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -273,6 +273,7 @@ parts:
       - python3-docutils
       - systemd-dev
     stage-packages:
+      - alsa-ucm-conf
       - libxfixes3
       - libcanberra0t64
       - libroc0.3


### PR DESCRIPTION
The alsa/ucm2 folder is empty because the package isn't staged.

This patch fixes it.